### PR TITLE
Create prompts folder structure with validator update

### DIFF
--- a/prompts/bn/greeting.md
+++ b/prompts/bn/greeting.md
@@ -1,0 +1,1 @@
+[bn] Translation coming soon.

--- a/prompts/bn/q1_phq.md
+++ b/prompts/bn/q1_phq.md
@@ -1,0 +1,1 @@
+[bn] Translation coming soon.

--- a/prompts/bn/q2_phq.md
+++ b/prompts/bn/q2_phq.md
@@ -1,0 +1,1 @@
+[bn] Translation coming soon.

--- a/prompts/bn/q3_phq.md
+++ b/prompts/bn/q3_phq.md
@@ -1,0 +1,1 @@
+[bn] Translation coming soon.

--- a/prompts/bn/q4_phq.md
+++ b/prompts/bn/q4_phq.md
@@ -1,0 +1,1 @@
+[bn] Translation coming soon.

--- a/prompts/bn/responses/score_green.md
+++ b/prompts/bn/responses/score_green.md
@@ -1,0 +1,1 @@
+[bn] Translation coming soon.

--- a/prompts/bn/responses/score_red.md
+++ b/prompts/bn/responses/score_red.md
@@ -1,0 +1,1 @@
+[bn] Translation coming soon.

--- a/prompts/bn/responses/score_yellow.md
+++ b/prompts/bn/responses/score_yellow.md
@@ -1,0 +1,1 @@
+[bn] Translation coming soon.

--- a/prompts/en/greeting.md
+++ b/prompts/en/greeting.md
@@ -1,0 +1,2 @@
+Hello! I'm going to ask you four quick questions about how you've been feeling.
+Please answer honestly by choosing the option that best describes you.

--- a/prompts/en/q1_phq.md
+++ b/prompts/en/q1_phq.md
@@ -1,0 +1,5 @@
+Over the last 2 weeks, how often have you felt nervous, anxious or on edge?
+1. Not at all
+2. Several days
+3. More than half the days
+4. Nearly every day

--- a/prompts/en/q2_phq.md
+++ b/prompts/en/q2_phq.md
@@ -1,0 +1,5 @@
+Over the last 2 weeks, how often have you been unable to stop or control worrying?
+1. Not at all
+2. Several days
+3. More than half the days
+4. Nearly every day

--- a/prompts/en/q3_phq.md
+++ b/prompts/en/q3_phq.md
@@ -1,0 +1,5 @@
+Over the last 2 weeks, how often have you had little interest or pleasure in doing things?
+1. Not at all
+2. Several days
+3. More than half the days
+4. Nearly every day

--- a/prompts/en/q4_phq.md
+++ b/prompts/en/q4_phq.md
@@ -1,0 +1,5 @@
+Over the last 2 weeks, how often have you felt down, depressed or hopeless?
+1. Not at all
+2. Several days
+3. More than half the days
+4. Nearly every day

--- a/prompts/en/responses/score_green.md
+++ b/prompts/en/responses/score_green.md
@@ -1,0 +1,1 @@
+Your answers suggest minimal distress. Keep taking care of yourself and reach out if things change.

--- a/prompts/en/responses/score_red.md
+++ b/prompts/en/responses/score_red.md
@@ -1,0 +1,1 @@
+Your responses show high distress. Please reach out to a mental health professional immediately.

--- a/prompts/en/responses/score_yellow.md
+++ b/prompts/en/responses/score_yellow.md
@@ -1,0 +1,1 @@
+You may be experiencing some distress. Consider speaking with a trusted friend or professional.

--- a/prompts/hi/greeting.md
+++ b/prompts/hi/greeting.md
@@ -1,0 +1,1 @@
+[hi] Translation coming soon.

--- a/prompts/hi/q1_phq.md
+++ b/prompts/hi/q1_phq.md
@@ -1,0 +1,1 @@
+[hi] Translation coming soon.

--- a/prompts/hi/q2_phq.md
+++ b/prompts/hi/q2_phq.md
@@ -1,0 +1,1 @@
+[hi] Translation coming soon.

--- a/prompts/hi/q3_phq.md
+++ b/prompts/hi/q3_phq.md
@@ -1,0 +1,1 @@
+[hi] Translation coming soon.

--- a/prompts/hi/q4_phq.md
+++ b/prompts/hi/q4_phq.md
@@ -1,0 +1,1 @@
+[hi] Translation coming soon.

--- a/prompts/hi/responses/score_green.md
+++ b/prompts/hi/responses/score_green.md
@@ -1,0 +1,1 @@
+[hi] Translation coming soon.

--- a/prompts/hi/responses/score_red.md
+++ b/prompts/hi/responses/score_red.md
@@ -1,0 +1,1 @@
+[hi] Translation coming soon.

--- a/prompts/hi/responses/score_yellow.md
+++ b/prompts/hi/responses/score_yellow.md
@@ -1,0 +1,1 @@
+[hi] Translation coming soon.

--- a/prompts/mr/greeting.md
+++ b/prompts/mr/greeting.md
@@ -1,0 +1,1 @@
+[mr] Translation coming soon.

--- a/prompts/mr/q1_phq.md
+++ b/prompts/mr/q1_phq.md
@@ -1,0 +1,1 @@
+[mr] Translation coming soon.

--- a/prompts/mr/q2_phq.md
+++ b/prompts/mr/q2_phq.md
@@ -1,0 +1,1 @@
+[mr] Translation coming soon.

--- a/prompts/mr/q3_phq.md
+++ b/prompts/mr/q3_phq.md
@@ -1,0 +1,1 @@
+[mr] Translation coming soon.

--- a/prompts/mr/q4_phq.md
+++ b/prompts/mr/q4_phq.md
@@ -1,0 +1,1 @@
+[mr] Translation coming soon.

--- a/prompts/mr/responses/score_green.md
+++ b/prompts/mr/responses/score_green.md
@@ -1,0 +1,1 @@
+[mr] Translation coming soon.

--- a/prompts/mr/responses/score_red.md
+++ b/prompts/mr/responses/score_red.md
@@ -1,0 +1,1 @@
+[mr] Translation coming soon.

--- a/prompts/mr/responses/score_yellow.md
+++ b/prompts/mr/responses/score_yellow.md
@@ -1,0 +1,1 @@
+[mr] Translation coming soon.

--- a/prompts/ta/greeting.md
+++ b/prompts/ta/greeting.md
@@ -1,0 +1,1 @@
+[ta] Translation coming soon.

--- a/prompts/ta/q1_phq.md
+++ b/prompts/ta/q1_phq.md
@@ -1,0 +1,1 @@
+[ta] Translation coming soon.

--- a/prompts/ta/q2_phq.md
+++ b/prompts/ta/q2_phq.md
@@ -1,0 +1,1 @@
+[ta] Translation coming soon.

--- a/prompts/ta/q3_phq.md
+++ b/prompts/ta/q3_phq.md
@@ -1,0 +1,1 @@
+[ta] Translation coming soon.

--- a/prompts/ta/q4_phq.md
+++ b/prompts/ta/q4_phq.md
@@ -1,0 +1,1 @@
+[ta] Translation coming soon.

--- a/prompts/ta/responses/score_green.md
+++ b/prompts/ta/responses/score_green.md
@@ -1,0 +1,1 @@
+[ta] Translation coming soon.

--- a/prompts/ta/responses/score_red.md
+++ b/prompts/ta/responses/score_red.md
@@ -1,0 +1,1 @@
+[ta] Translation coming soon.

--- a/prompts/ta/responses/score_yellow.md
+++ b/prompts/ta/responses/score_yellow.md
@@ -1,0 +1,1 @@
+[ta] Translation coming soon.

--- a/scripts/validate_locale.py
+++ b/scripts/validate_locale.py
@@ -13,10 +13,13 @@ errors = []
 
 for lang in LANG_CODES:
     lang_dir = os.path.join(PROMPTS_DIR, lang)
-    files = set(os.listdir(lang_dir))
+    entries = set(os.listdir(lang_dir))
+    files = {f for f in entries if os.path.isfile(os.path.join(lang_dir, f))}
+    subdirs = {d for d in entries if os.path.isdir(os.path.join(lang_dir, d))}
     # Check same filenames
-    if files != MASTER_FILES:
-        errors.append(f"[Structure] Language '{lang}' has files {files.symmetric_difference(MASTER_FILES)} missing or extra.")
+    if entries != MASTER_FILES:
+        diff = entries.symmetric_difference(MASTER_FILES)
+        errors.append(f"[Structure] Language '{lang}' has files {diff} missing or extra.")
     # Check each file length
     for fname in files:
         path = os.path.join(lang_dir, fname)


### PR DESCRIPTION
## Summary
- add `prompts/` with English prompts and placeholders for other languages
- adjust `validate_locale.py` to ignore subdirectories
- include placeholder text for translations

## Testing
- `python3 scripts/validate_locale.py`

------
https://chatgpt.com/codex/tasks/task_e_6843f55049748326aa3050a3f36df4ae