### PR TITLE
Fix README overview wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Mental Health Prompts for Mental Health Screening
 
-Open-source library of multi-lingual WhatsApp chat prompts for lightweight mental-health triage (PHQ‑4 / GAD‑2 flows) in India.
+Open-source library of **multilingual** WhatsApp chat prompts for lightweight mental-health triage (PHQ‑4 / GAD‑2 flows) in India.
 
 📖 Overview
 


### PR DESCRIPTION
## Summary
- emphasize that prompts are **multilingual** in the README

## Testing
- `python scripts/validate_locale.py` *(fails: FileNotFoundError)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f5c1fc208326923d1cb24dae5ec5