### PR TITLE
Fix validation script for nested files and whitespace

### DIFF
--- a/scripts/validate_locale.py
+++ b/scripts/validate_locale.py
@@ -2,7 +2,9 @@ import os
 import sys
 import re
 
-DEFAULT_PROMPTS_DIR = os.path.join(os.path.dirname(__file__), '..', 'prompts')
+DEFAULT_PROMPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'prompts')
+)
 MAX_LENGTH = 600
 
 def validate_locales(prompts_dir: str = DEFAULT_PROMPTS_DIR) -> list:
@@ -12,28 +14,39 @@ def validate_locales(prompts_dir: str = DEFAULT_PROMPTS_DIR) -> list:
     """
     lang_codes = [d for d in os.listdir(prompts_dir)
                   if os.path.isdir(os.path.join(prompts_dir, d))]
-    master_files = set(os.listdir(os.path.join(prompts_dir, 'en')))
+    # Build the reference file list from the English directory
+    master_dir = os.path.join(prompts_dir, 'en')
+    master_files = set()
+    for root, _, files in os.walk(master_dir):
+        for f in files:
+            rel_path = os.path.relpath(os.path.join(root, f), master_dir)
+            master_files.add(rel_path)
 
     errors = []
 
     for lang in lang_codes:
         lang_dir = os.path.join(prompts_dir, lang)
-        entries = set(os.listdir(lang_dir))
-        files = {f for f in entries if os.path.isfile(os.path.join(lang_dir, f))}
+        file_set = set()
+        for root, _, files in os.walk(lang_dir):
+            for f in files:
+                rel_path = os.path.relpath(os.path.join(root, f), lang_dir)
+                file_set.add(rel_path)
 
         # Skip structure check for 'multi' directory
-        if lang != 'multi' and entries != master_files:
-            diff = entries.symmetric_difference(master_files)
-            errors.append(f"[Structure] Language '{lang}' has files {diff} missing or extra.")
+        if lang != 'multi' and file_set != master_files:
+            diff = file_set.symmetric_difference(master_files)
+            errors.append(
+                f"[Structure] Language '{lang}' has files {diff} missing or extra."
+            )
 
         # Check each file for length and trailing whitespace
-        for fname in files:
+        for fname in file_set:
             path = os.path.join(lang_dir, fname)
             if not os.path.isfile(path):
                 continue
             with open(path, 'r', encoding='utf-8') as f:
-                content = f.read().strip()
-            length = len(content)
+                content = f.read()
+            length = len(content.rstrip('\n'))
             if length > MAX_LENGTH:
                 errors.append(
                     f"[Length] {lang}/{fname} is {length} chars (max {MAX_LENGTH}).")

--- a/tests/test_validate_locale.py
+++ b/tests/test_validate_locale.py
@@ -47,3 +47,27 @@ def test_validate_locale_handles_directories(tmp_path):
     errors = validate_locale.validate_locales(prompts_dir=prompts_dir)
     assert errors == []
 
+
+def test_missing_subdirectory_file_detected(tmp_path):
+    prompts_dir = setup_prompts(tmp_path)
+
+    os.remove(os.path.join(prompts_dir, 'hi', 'responses', 'score_green.md'))
+
+    errors = validate_locale.validate_locales(prompts_dir=prompts_dir)
+    assert any('responses/score_green.md' in e for e in errors)
+
+
+def test_trailing_whitespace_detected(tmp_path):
+    prompts_dir = setup_prompts(tmp_path)
+
+    file_path = os.path.join(prompts_dir, 'hi', 'greeting.md')
+    with open(file_path, 'a', encoding='utf-8') as f:
+        f.write('  ')
+
+    errors = validate_locale.validate_locales(prompts_dir=prompts_dir)
+    assert any('Trailing whitespace' in e for e in errors)
+
+
+def test_default_prompts_dir_absolute():
+    assert os.path.isabs(validate_locale.DEFAULT_PROMPTS_DIR)
+


### PR DESCRIPTION
## Summary
- fix locale validator to recurse into subdirectories
- only strip newline characters when checking file length
- use absolute path for default prompts directory
- expand tests for new validation behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684421f929a08326995de6e7febc2905